### PR TITLE
fix(scripts/lnk): A logic error in generate_shortcode didn't generate…

### DIFF
--- a/scripts/lnk
+++ b/scripts/lnk
@@ -2,11 +2,14 @@
 LOCAL_CONFIG="$HOME/.vanityURLs.conf"
 STATIC_FILE="static.lnk"
 MAX_ATTEMPTS=100
+SHORTCODE=""
 
 function print_usage() {
   echo "There are two valid ways to call this script:"
   echo -e "1) A random shortcode will be generated automatically:\n\t./scripts/lnk [LONG_URL]"
   echo -e "2) Specify the shortcode you want:\n\t./scripts/lnk [LONG_URL] [SHORTCODE]"
+  echo
+  echo -e "You may call this script with DRY_RUN=true for testing purposes."
   exit 1
 }
 
@@ -28,12 +31,15 @@ function generate_shortcode() {
     for i in $(seq 1 $SHORTCODE_LENGTH); do
       random_string="${random_string}$(random_char)"
     done
+    if [ "$DRY_RUN" = true ]; then
+      echo "Attempt $counter: $random_string"
+    fi
 
     # Check if "/$random_string is already in the file
     if grep -q "^/$random_string" "$STATIC_FILE"; then
       ((counter++))
     else
-      echo $random_string
+      SHORTCODE=$random_string
       break
     fi
   done
@@ -57,7 +63,7 @@ case "$#" in
     ;;
   1)
     LONG_URL="$1"
-    SHORTCODE=$(generate_shortcode)
+    generate_shortcode  # This sets SHORTCODE
     if [ "$SHORTCODE" = "" ]; then
       echo "Error: $MAX_ATTEMPTS attempts were made to find a unique random string for your URL in $STATIC_FILE, but no success.
       Aborting. Consider raising the value of SHORTCODE_LENGTH in '$LOCAL_CONFIG'."

--- a/scripts/lnk
+++ b/scripts/lnk
@@ -21,15 +21,15 @@ function random_char() {
 }
 
 function generate_shortcode() {
-  # Generate a random string
-  random_string=""
-  for i in $(seq 1 $SHORTCODE_LENGTH); do
-    random_string="${random_string}$(random_char)"
-  done
-
-  # Check if "/$random_string is already in the file
   counter=0  # Initialize the counter
   while [ "$counter" -le $MAX_ATTEMPTS ]; do
+    # Generate a random string
+    random_string=""
+    for i in $(seq 1 $SHORTCODE_LENGTH); do
+      random_string="${random_string}$(random_char)"
+    done
+
+    # Check if "/$random_string is already in the file
     if grep -q "^/$random_string" "$STATIC_FILE"; then
       ((counter++))
     else


### PR DESCRIPTION
… a new random string on different attempts

### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are fixing a specific issue, include "Fixes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because I noticed I was frequently getting this error:

```
Error: 1000 attempts were made to find a unique random string for your URL in static.lnk, but no success.
      Aborting. Consider raising the value of SHORTCODE_LENGTH in '/Users/felix.leger/.vanityURLs.conf'.
```

However, I could work around this error if I just ran the command one more time. I investigated why this was happening and found the problem. The logic in `generate_shortcode` was wrong. We weren't generating a new shortcode if the first attempt was found in `static.lnk`.

### Detail

This Pull Request fixes the logic of the `generate_shortcode` function in `scripts/lnk`

### Additional information

I left the snippet of code that allowed me to perform this debug, in case it is useful in the future. When running in DRY_RUN mode, the script will output to the screen each of its attempts.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
