### PR TITLE
fix(scripts/lnk): add space after shortcode when grepping to avoid am…

### DIFF
--- a/scripts/lnk
+++ b/scripts/lnk
@@ -36,7 +36,7 @@ function generate_shortcode() {
     fi
 
     # Check if "/$random_string is already in the file
-    if grep -q "^/$random_string" "$STATIC_FILE"; then
+    if grep -q "^/$random_string " "$STATIC_FILE"; then
       ((counter++))
     else
       SHORTCODE=$random_string
@@ -73,7 +73,7 @@ case "$#" in
   2)
     LONG_URL="$1"
     SHORTCODE="$2"
-    if grep -q "^/$SHORTCODE" "$STATIC_FILE"; then
+    if grep -q "^/$SHORTCODE " "$STATIC_FILE"; then
       echo "Error: /$SHORTCODE is already taken in $STATIC_FILE."
       exit 1
     fi


### PR DESCRIPTION
…biguous matches

<!--
Thanks for contributing to Rails!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the repo.

Create a pull request when it is ready for review and feedback
from the team :).

About this template

The following template aims to help contributors write a good description for their pull requests.
We'd like you to provide a description of the changes in your pull request (i.e. bugs fixed or features added), motivation behind the changes, and complete the checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a typo). -->

### Motivation / Background



This Pull Request has been created because I noticed that the search function used by `scripts/lnk` had a flaw. For example, if `static.lnk` contained:

```
/abc https://example.com
```

Running the following would have resulted in an error:

```
./scripts/lnk https://new-example.com ab
```

Because the `grep` within `lnk` would have returned a partial hit on the existing line containing `/abc`. Thus, by adding a space after the short code in `/scripts/lnk` in the call to `grep`, we ensure that a code such as `ab` can be added even if a longer code containing it (e.g. `abc`) already exists.

### Detail

This Pull Request simply adds a space after the shortcode where we run `grep` in `scripts/lnk` to detect if a shortcode is already used.

### Additional information

n/a

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
