### PR TITLE
fix(scripts/lnk): modify grep command to better search for existing urls

### DIFF
--- a/scripts/lnk
+++ b/scripts/lnk
@@ -84,9 +84,9 @@ case "$#" in
 esac
 
 # If the long URL is already being redirected, notify the user
-if grep -q -P "$LONG_URL( |$)" $STATIC_FILE; then
+if grep -q -F "$LONG_URL" "$STATIC_FILE"; then
   echo "This URL is already being redirected:"
-  grep -P "$LONG_URL( |$)" $STATIC_FILE
+  grep -F "$LONG_URL" "$STATIC_FILE"
   exit 1
 fi
 


### PR DESCRIPTION
<!--
Thanks for contributing to VanityURLs!

Please do not make *Draft* pull requests, as they still send
notifications to everyone watching the repo.

Create a pull request when it is ready for review and feedback from
the team :).

About this template

The following template aims to help contributors write a good
description for their pull requests.  We'd like you to provide a
description of the changes in your pull request (i.e. bugs fixed or
features added), motivation behind the changes, and complete the
checklist below before opening a pull request.

Feel free to discard it if you need to (e.g. when you just fix a
typo).
-->

### Motivation / Background

I identified a bug when trying to create a short URL for a Confluence link. The (obfuscated) link in question looked like `https://company.atlassian.net/wiki/spaces/DEV/pages/684064/DEV+-+Proc+dures+-+Workflow`. When calling `scripts/lnk` with that URL, instead of giving me an error that the link already existed in my `static.lnk`, it created a new short URL.

I realized it is better to use grep with `-F` instead of `-P`. Instead of looking for a regex, we instead look for the URL itself with `-F`. Indeed, from the manual:

```
     -F, --fixed-strings
             Interpret pattern as a set of fixed strings (i.e., force grep to behave as fgrep).
```

### Detail

This Pull Request changes `grep` options when searching if the long URL is already being redirected. Instead of using pattern recognition with `-P`, we use `-F`, which is more robust because it exactly matches the URL..

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a detailed description of what changed and why. If this PR fixes a related issue include it in the commit message. Ex: `[Fix #issue-number]`
