### PR TITLE
Work/complexity budget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ custom/v8s-local-config.json
 *.old
 *.swp
 .DS_Store
-build/
+/build/
 /functions/
 /src/
 build/blocklist.generated.json

--- a/docs/adr/0016-adopt-complexity-budget.md
+++ b/docs/adr/0016-adopt-complexity-budget.md
@@ -1,0 +1,50 @@
+# 0016. Adopt a complexity budget and refactor toward functional core
+
+Date: 2026-06-04
+
+Status: Accepted
+
+## Context
+
+The vanityURLs code repository has several large operational files. The largest files are not wrong because they are
+large, but they mix orchestration, file system access, prompts, network calls, validation, and pure transformations in
+the same modules. That makes growth hard to notice and makes focused unit testing harder than necessary.
+
+The current `npm run lint` hygiene checker verifies formatting-adjacent repository rules, JSON validity, and JavaScript
+syntax. It does not measure cyclomatic complexity, cognitive complexity, nesting depth, parameter count, or
+file/function size.
+
+## Decision
+
+Add ESLint with a flat config and `eslint-plugin-sonarjs` as a complexity visibility layer. Wire it into `npm run lint`
+and therefore into `npm run check`.
+
+Use `npm run lint:complexity` for a concise summary and `npm run lint:complexity:raw` for the full ESLint output. The
+summary command writes the complete warning/error data to `build/eslint-complexity-report.json`.
+
+Initial complexity budgets are warning-level so the current repository stays green:
+
+- cyclomatic complexity: 12
+- cognitive complexity: 15
+- maximum lines per file: 400
+- maximum lines per function: 60
+- maximum nesting depth: 4
+- maximum parameters: 4
+
+Treat these warnings as a ratchet. New code should stay inside the budget. Existing violations should be reduced when a
+module is touched for related work. After large files are decomposed, tighten the rules or convert selected budgets from
+warnings to errors.
+
+Refactor large modules toward a functional-core, imperative-shell shape:
+
+- keep file system, process, prompt, and network operations in thin orchestrators
+- move pure transformations into `scripts/lib/**` or `scripts/workers/lib/**`
+- test the pure modules directly
+- decompose scripts by phase, such as build pipeline phases and install wizard phases
+
+## Consequences
+
+- `npm run check` now reports complexity growth without blocking current releases.
+- Large files can be refactored incrementally instead of through a high-risk rewrite.
+- The repository gains an objective signal for future refactoring priorities.
+- Warning-only budgets require maintainer discipline until the ratchet is tightened.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,44 @@
+import sonarjs from "eslint-plugin-sonarjs";
+
+const COMMON_GLOBALS = {
+  AbortController: "readonly",
+  Buffer: "readonly",
+  Headers: "readonly",
+  Request: "readonly",
+  Response: "readonly",
+  URL: "readonly",
+  URLSearchParams: "readonly",
+  console: "readonly",
+  crypto: "readonly",
+  fetch: "readonly",
+  process: "readonly",
+  setTimeout: "readonly",
+  clearTimeout: "readonly"
+};
+
+const COMPLEXITY_BUDGET = {
+  complexity: ["warn", { max: 12 }],
+  "max-depth": ["warn", 4],
+  "max-lines": ["warn", { max: 400, skipBlankLines: true, skipComments: true }],
+  "max-lines-per-function": ["warn", { max: 60, skipBlankLines: true, skipComments: true, IIFEs: true }],
+  "max-params": ["warn", 4],
+  "sonarjs/cognitive-complexity": ["warn", 15]
+};
+
+export default [
+  {
+    ignores: ["build/**", "src/**", "node_modules/**", ".wrangler/**", "coverage/**", "!scripts/lib/build/**"]
+  },
+  {
+    files: ["**/*.{js,mjs}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      globals: COMMON_GLOBALS,
+      sourceType: "module"
+    },
+    plugins: {
+      sonarjs
+    },
+    rules: COMPLEXITY_BUDGET
+  }
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,254 @@
       "name": "vanityURLs",
       "version": "3.2.1",
       "devDependencies": {
+        "eslint": "^10.4.1",
+        "eslint-plugin-sonarjs": "^4.0.3",
         "prettier": "^3.8.3",
         "svgo": "^4.0.1"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^3.0.5",
+        "debug": "^4.3.1",
+        "minimatch": "^10.2.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^1.2.1",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/boolbase": {
@@ -19,6 +265,42 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
@@ -27,6 +309,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/css-select": {
@@ -109,6 +406,31 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -181,12 +503,464 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
+      "integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.6.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "minimatch": "^10.2.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.0.3.tgz",
+      "integrity": "sha512-5drkJKLC9qQddIiaATV0e8+ygbUc7b0Ti6VB7M2d3jmKNh3X0RaiIJYTs3dr9xnlhlrxo+/s1FoO3Jgv6O/c7g==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.4.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.5",
+        "scslre": "^0.3.0",
+        "semver": "^7.7.4",
+        "ts-api-utils": "^2.5.0",
+        "typescript": ">=5"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^5.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -201,12 +975,92 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
     },
     "node_modules/prettier": {
       "version": "3.8.3",
@@ -224,6 +1078,43 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/sax": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
@@ -232,6 +1123,57 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.2.tgz",
+      "integrity": "sha512-c8jsqUZm3omBOI66G90z1Dyw5z622G8oLG+omfsHBJf3CWQTlOcwOjvOG6wtiNfW6anKm/eA39LMwMtMez2TiQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/source-map-js": {
@@ -268,6 +1210,95 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/svgo"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "generate:blocklist": "node scripts/generate-blocklist.mjs build/blocklist.generated.json",
     "generate:manifest": "node scripts/generate-release-manifest.mjs",
     "help": "node scripts/help.mjs",
-    "lint": "node scripts/lint.mjs",
+    "lint": "npm run lint:hygiene && npm run lint:complexity",
+    "lint:complexity": "node scripts/complexity-report.mjs",
+    "lint:complexity:raw": "eslint .",
+    "lint:hygiene": "node scripts/lint.mjs",
     "local-install": "node scripts/local-install.mjs",
     "local-publish": "node scripts/local-publish.mjs",
     "optimize:badges": "find defaults/public -name 'v8s-redirected*.svg' -print0 | xargs -0 svgo --config scripts/svgo.config.mjs",
@@ -26,10 +29,13 @@
     "smoke": "npm run smoke:analytics",
     "smoke:analytics": "npm run build && node scripts/smoke-analytics.mjs",
     "test": "npm run test:all",
-    "test:all": "npm run test:worker && npm run test:registry && npm run test:install && npm run test:maintenance",
+    "test:all": "npm run test:worker && npm run test:registry && npm run test:install && npm run test:maintenance && npm run test:upstream-release && npm run test:build-core && npm run test:build-html-core",
+    "test:build-core": "node scripts/build-site-core.test.mjs",
+    "test:build-html-core": "node scripts/build-html-core.test.mjs",
     "test:install": "node scripts/install.test.mjs",
     "test:maintenance": "node scripts/maintenance.test.mjs",
     "test:registry": "node scripts/registry.test.mjs",
+    "test:upstream-release": "node scripts/upstream-release.test.mjs",
     "test:worker": "node scripts/workers/worker.test.mjs",
     "upgrade": "node scripts/upgrade.mjs",
     "update": "node scripts/upgrade.mjs",
@@ -44,6 +50,8 @@
     "ci:check": "npm run check"
   },
   "devDependencies": {
+    "eslint": "^10.4.1",
+    "eslint-plugin-sonarjs": "^4.0.3",
     "prettier": "^3.8.3",
     "svgo": "^4.0.1"
   }

--- a/scripts/build-html-core.test.mjs
+++ b/scripts/build-html-core.test.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import {
+  insertBeforeFirstStylesheet,
+  insertBeforeHeadClose,
+  normalizeHtmlHead,
+  normalizePublicAssetVersions,
+  THEME_OVERRIDE_SCRIPT
+} from "./lib/build/html-core.mjs";
+
+{
+  assert.equal(
+    normalizePublicAssetVersions('<link rel="stylesheet" href="/style.css">', "123"),
+    '<link rel="stylesheet" href="/style.css?v=123">'
+  );
+  assert.equal(
+    normalizePublicAssetVersions('<link rel="stylesheet" href="/style.css?v=1">', "123"),
+    '<link rel="stylesheet" href="/style.css?v=123">'
+  );
+}
+
+{
+  assert.equal(insertBeforeHeadClose("<html><head></head></html>", "X"), "<html><head>X</head></html>");
+  assert.equal(
+    insertBeforeFirstStylesheet('<head><link rel="stylesheet" href="/style.css"></head>', "X"),
+    '<head>X<link rel="stylesheet" href="/style.css"></head>'
+  );
+  assert.equal(insertBeforeFirstStylesheet("<head></head>", "X"), "<head>X</head>");
+}
+
+{
+  const normalized = normalizeHtmlHead(
+    '<html><head><link rel="stylesheet" href="/style.css"></head><body></body></html>',
+    { assetVersion: "123" }
+  );
+
+  assert(normalized.includes('href="/style.css?v=123"'));
+  assert(normalized.includes('rel="icon"'));
+  assert(normalized.includes('rel="apple-touch-icon"'));
+  assert(normalized.includes("data-v8s-theme-override"));
+  assert(normalized.indexOf("data-v8s-theme-override") < normalized.indexOf('rel="stylesheet"'));
+}
+
+{
+  const original =
+    '<head><script data-v8s-theme-override></script><link rel="icon" href="/custom.svg"><link rel="apple-touch-icon" href="/custom.png"><link rel="stylesheet" href="/style.css"></head>';
+  const normalized = normalizeHtmlHead(original, { assetVersion: "123" });
+
+  assert.equal((normalized.match(/data-v8s-theme-override/g) || []).length, 1);
+  assert.equal((normalized.match(/rel="icon"/g) || []).length, 1);
+  assert.equal((normalized.match(/rel="apple-touch-icon"/g) || []).length, 1);
+}
+
+assert(THEME_OVERRIDE_SCRIPT.includes("applyThemeImages"));
+
+console.log("build html core tests ok");

--- a/scripts/build-site-core.test.mjs
+++ b/scripts/build-site-core.test.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import {
+  encodePathSegment,
+  escapeHtml,
+  escapeHtmlAttribute,
+  hasConfiguredSlogan,
+  legalPageSlugs,
+  legalPagesEnabled,
+  localizedSlogan,
+  normalizeSecurityTxtValue,
+  renderBrandingSlogan,
+  renderConfiguredWordmark,
+  siteManifestShortName,
+  validateOperatorConfig,
+  validateSecurityConfig,
+  validateTrustConfig,
+  withTheme
+} from "./lib/build/site-core.mjs";
+
+{
+  assert.equal(legalPagesEnabled({}), true);
+  assert.equal(legalPagesEnabled({ operator: { legal_pages_enabled: false } }), false);
+  assert.deepEqual(legalPageSlugs({}), ["privacy", "terms", "abuse", "security"]);
+  assert.deepEqual(legalPageSlugs({ operator: { legal_pages_enabled: false } }), ["abuse"]);
+}
+
+{
+  assert.equal(
+    siteManifestShortName({
+      branding: { wordmark: { black: "Vanity", green: "URLs" } },
+      operator: { short_domain: "go.example" }
+    }),
+    "go.example"
+  );
+  assert.equal(siteManifestShortName({ branding: { wordmark: { black: "go", green: ".ex" } } }), "go.ex");
+}
+
+{
+  assert.equal(normalizeSecurityTxtValue(" security@example.com\r\nIgnored"), "security@example.comIgnored");
+  assert.equal(escapeHtml('<a&b>"'), "&lt;a&amp;b&gt;&quot;");
+  assert.equal(escapeHtmlAttribute("Benoit's"), "Benoit&#39;s");
+  assert.equal(encodePathSegment("lookup/nested value"), "lookup/nested%20value");
+  assert.equal(withTheme("/lookup?x=1", "dark"), "/lookup?x=1&theme=dark");
+}
+
+{
+  const operator = {
+    legal_name: "Dicaire",
+    operator_domain: "https://dicaire.com/about"
+  };
+  assert.equal(
+    renderBrandingSlogan("A Dicaire service", operator),
+    'A <a href="https://dicaire.com">Dicaire</a> service'
+  );
+  assert.equal(localizedSlogan({ en: "Hello", fr: "Bonjour" }, "fr"), "Bonjour");
+  assert.equal(hasConfiguredSlogan({ en: "" }), false);
+  assert.equal(hasConfiguredSlogan({ en: "Hello" }), true);
+  assert.equal(
+    renderConfiguredWordmark({ branding: { wordmark: { black: "Vanity", green: "URLs" } } }),
+    "<span>Vanity</span><span>URLs</span>"
+  );
+}
+
+{
+  const validOperator = {
+    abuse_contact: "abuse@dicaire.com",
+    abuse_response_window: "48 hours",
+    analytics_disclosure: "Analytics disclosed",
+    contact_email: "hello@dicaire.com",
+    governing_law: "Quebec",
+    jurisdiction: "Canada",
+    last_updated: "2026-06-04",
+    legal_name: "Example Inc.",
+    privacy_contact: "privacy@dicaire.com",
+    security_contact: "security@dicaire.com",
+    short_domain: "go.example",
+    umami_geo_ip_mode: "truncated"
+  };
+
+  assert.deepEqual(validateOperatorConfig(validOperator), []);
+  assert.deepEqual(validateTrustConfig(validOperator), []);
+  assert.deepEqual(validateSecurityConfig(validOperator), []);
+  assert.deepEqual(validateSecurityConfig({ ...validOperator, security_contact: "todo" }), ["security_contact"]);
+  assert(validateOperatorConfig({ ...validOperator, legal_name: "TODO" }).includes("legal_name"));
+}
+
+console.log("build site core tests ok");

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -12,6 +12,25 @@ import {
   supportedLanguages,
   writeSiteConfig as writeRuntimeSiteConfig
 } from "./lib/build-assets.mjs";
+import {
+  encodePathSegment,
+  escapeHtml,
+  escapeHtmlAttribute,
+  hasConfiguredSlogan,
+  legalPageSlugs,
+  legalPagesEnabled,
+  localizedSlogan,
+  localizedSloganLinkText,
+  normalizeSecurityTxtValue,
+  renderBrandingSlogan,
+  renderConfiguredWordmark,
+  siteManifestShortName,
+  validateOperatorConfig,
+  validateSecurityConfig,
+  validateTrustConfig,
+  withTheme
+} from "./lib/build/site-core.mjs";
+import { normalizeHtmlHead } from "./lib/build/html-core.mjs";
 
 const ROOT = process.cwd();
 const BUILD_DIR = path.join(ROOT, "build");
@@ -27,7 +46,6 @@ const WORKER_SOURCE_DIR = path.join(ROOT, "scripts", "workers");
 const RUNTIME_SOURCE_DIR = path.join(ROOT, "src");
 const LANGUAGE_METADATA_PATH = path.join(DEFAULTS_DIR, "v8s-language-metadata.json");
 const LEGAL_CONTENT_PATH = path.join(DEFAULTS_DIR, "legal", "v8s-legal-content.json");
-const PUBLIC_ASSET_VERSION = "20260601";
 
 // Build order matters: product defaults are copied first, instance custom files overlay them,
 // then runtime JSON and generated Worker source are written for Wrangler.
@@ -40,14 +58,6 @@ function run(command) {
     cwd: ROOT,
     stdio: "inherit"
   });
-}
-
-function normalizeDomain(value) {
-  return String(value || "")
-    .trim()
-    .replace(/^https?:\/\//i, "")
-    .replace(/\/.*$/g, "")
-    .toLowerCase();
 }
 
 function loadSiteConfig() {
@@ -149,14 +159,6 @@ function renderSecurityTxt(siteConfig) {
   }
 }
 
-function legalPagesEnabled(siteConfig) {
-  return siteConfig?.operator?.legal_pages_enabled !== false;
-}
-
-function legalPageSlugs(siteConfig) {
-  return legalPagesEnabled(siteConfig) ? ["privacy", "terms", "abuse", "security"] : ["abuse"];
-}
-
 function removeDeferredLegalPages(siteConfig) {
   if (legalPagesEnabled(siteConfig)) return;
 
@@ -203,25 +205,6 @@ function renderSiteWebManifests(siteConfig) {
   }
 }
 
-function siteManifestShortName(siteConfig) {
-  const branding = siteConfig?.branding || {};
-  const wordmark = branding.wordmark || {};
-  const candidates = [
-    branding.domain,
-    siteConfig?.operator?.short_domain,
-    `${wordmark.black || ""}${wordmark.green || ""}`,
-    "VanityURLs"
-  ];
-
-  return candidates.map((value) => String(value || "").trim()).find(Boolean) || "VanityURLs";
-}
-
-function normalizeSecurityTxtValue(value) {
-  return String(value || "")
-    .trim()
-    .replace(/[\r\n]/g, "");
-}
-
 function legalPagePaths(language, slug) {
   return language === "en"
     ? [path.join(BUILD_DIR, `${slug}.html`), path.join(BUILD_DIR, "en", `${slug}.html`)]
@@ -255,67 +238,6 @@ function normalizeHtmlHeadAssets() {
   rewriteHtmlFiles(BUILD_DIR, (html) => normalizeHtmlHead(html));
 }
 
-function normalizeHtmlHead(html) {
-  let normalized = html;
-  normalized = normalizePublicAssetVersions(normalized);
-
-  if (!normalized.includes('rel="icon"')) {
-    normalized = insertBeforeHeadClose(normalized, '  <link rel="icon" type="image/svg+xml" href="/favicon.svg">\n');
-  }
-
-  if (!normalized.includes('rel="apple-touch-icon"')) {
-    normalized = insertBeforeHeadClose(normalized, '  <link rel="apple-touch-icon" href="/apple-touch-icon.png">\n');
-  }
-
-  if (!normalized.includes("data-v8s-theme-override")) {
-    normalized = insertBeforeFirstStylesheet(normalized, `${THEME_OVERRIDE_SCRIPT}\n`);
-  }
-
-  return normalized;
-}
-
-function normalizePublicAssetVersions(html) {
-  return html.replace(/(href=["']\/style\.css)(?:\?v=\d+)?(["'])/g, `$1?v=${PUBLIC_ASSET_VERSION}$2`);
-}
-
-function insertBeforeHeadClose(html, insertion) {
-  return html.replace(/<\/head>/i, `${insertion}</head>`);
-}
-
-function insertBeforeFirstStylesheet(html, insertion) {
-  if (/<link\s+[^>]*rel=["']stylesheet["'][^>]*>/i.test(html)) {
-    return html.replace(/(<link\s+[^>]*rel=["']stylesheet["'][^>]*>)/i, `${insertion}$1`);
-  }
-
-  return insertBeforeHeadClose(html, insertion);
-}
-
-const THEME_OVERRIDE_SCRIPT = `  <script data-v8s-theme-override>
-    (() => {
-      const theme = new URLSearchParams(window.location.search).get("theme");
-      if (theme !== "light" && theme !== "dark") return;
-
-      document.documentElement.dataset.theme = theme;
-
-      const applyThemeImages = () => {
-        document.querySelectorAll('picture source[media*="prefers-color-scheme"][srcset]').forEach((source) => {
-          const image = source.parentElement?.querySelector("img");
-          const candidate =
-            theme === "dark"
-              ? source.getAttribute("srcset")?.split(",")[0]?.trim()?.split(/\\s+/)[0]
-              : image?.getAttribute("src");
-          if (image && candidate) image.src = candidate;
-        });
-      };
-
-      if (document.readyState === "loading") {
-        document.addEventListener("DOMContentLoaded", applyThemeImages, { once: true });
-      } else {
-        applyThemeImages();
-      }
-    })();
-  </script>`;
-
 function isDefaultLegalTemplate(filePath) {
   if (!fs.existsSync(filePath)) return false;
   const html = fs.readFileSync(filePath, "utf8");
@@ -324,68 +246,6 @@ function isDefaultLegalTemplate(filePath) {
     html.includes("Modèle par défaut à adapter par le propriétaire de l'instance.") ||
     html.includes('data-v8s-default-template="true"')
   );
-}
-
-function validateOperatorConfig(operator) {
-  const required = [
-    "legal_name",
-    "short_domain",
-    "jurisdiction",
-    "governing_law",
-    "contact_email",
-    "privacy_contact",
-    "abuse_contact",
-    "security_contact",
-    "last_updated",
-    "umami_geo_ip_mode",
-    "analytics_disclosure",
-    "abuse_response_window"
-  ];
-  const issues = required.filter((field) => isPlaceholderValue(operator[field]));
-
-  for (const field of ["contact_email", "privacy_contact", "abuse_contact", "security_contact"]) {
-    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(String(operator[field]))) {
-      issues.push(field);
-    }
-  }
-
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(operator.last_updated))) {
-    issues.push("last_updated");
-  }
-
-  return [...new Set(issues)];
-}
-
-function validateTrustConfig(operator) {
-  const required = ["short_domain", "abuse_contact", "security_contact", "last_updated", "abuse_response_window"];
-  const issues = required.filter((field) => isPlaceholderValue(operator[field]));
-
-  for (const field of ["abuse_contact", "security_contact"]) {
-    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(String(operator[field]))) {
-      issues.push(field);
-    }
-  }
-
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(operator.last_updated))) {
-    issues.push("last_updated");
-  }
-
-  return [...new Set(issues)];
-}
-
-function validateSecurityConfig(operator) {
-  const required = ["short_domain", "security_contact", "last_updated"];
-  const issues = required.filter((field) => isPlaceholderValue(operator[field]));
-
-  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(String(operator.security_contact))) {
-    issues.push("security_contact");
-  }
-
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(operator.last_updated))) {
-    issues.push("last_updated");
-  }
-
-  return [...new Set(issues)];
 }
 
 function effectiveOperator(operator) {
@@ -438,20 +298,6 @@ function gitLastUpdatedDate() {
   } catch {
     return "";
   }
-}
-
-function isPlaceholderValue(value) {
-  const normalized = String(value || "")
-    .trim()
-    .toLowerCase();
-  return (
-    !normalized ||
-    ["todo", "tbd", "to be defined", "changeme", "change-me", "default", "owner", "example", "example.com"].includes(
-      normalized
-    ) ||
-    normalized.includes("example.") ||
-    normalized.includes("your-")
-  );
 }
 
 function replaceLegalContent(html, rendered, title = "") {
@@ -569,48 +415,6 @@ function isStatsDashboardFile(filePath) {
 function languageForBuildHtmlFile(filePath) {
   const [firstSegment] = path.relative(BUILD_DIR, filePath).split(path.sep);
   return LANGUAGE_METADATA[firstSegment] ? firstSegment : "en";
-}
-
-function hasConfiguredSlogan(slogan) {
-  if (slogan && typeof slogan === "object" && !Array.isArray(slogan)) {
-    return Object.values(slogan).some((value) => String(value || "").trim());
-  }
-  return Boolean(String(slogan || "").trim());
-}
-
-function renderBrandingSlogan(slogan, operator = {}, linkText = "") {
-  const rendered = escapeHtml(slogan || "");
-  const legalName = String(operator?.legal_name || "").trim();
-  const operatorDomain = normalizeDomain(operator?.operator_domain || "");
-  if (!rendered || !legalName || !operatorDomain) return rendered;
-
-  const linkCandidates = [String(linkText || "").trim(), legalName].filter(Boolean);
-
-  for (const candidate of linkCandidates) {
-    const escapedText = escapeHtml(candidate);
-    if (rendered.includes(escapedText)) {
-      return rendered.replace(
-        escapedText,
-        `<a href="https://${escapeHtmlAttribute(operatorDomain)}">${escapedText}</a>`
-      );
-    }
-  }
-
-  return rendered;
-}
-
-function localizedSlogan(slogans, language = "en") {
-  if (slogans && typeof slogans === "object" && !Array.isArray(slogans)) {
-    return slogans[language] || slogans.en || "";
-  }
-  return String(slogans || "");
-}
-
-function localizedSloganLinkText(linkTexts, language = "en") {
-  if (linkTexts && typeof linkTexts === "object" && !Array.isArray(linkTexts)) {
-    return linkTexts[language] || linkTexts.en || "";
-  }
-  return String(linkTexts || "");
 }
 
 function removeLegalRedirectedBadge(html) {
@@ -804,15 +608,6 @@ function buildLocalizedStatsPages(siteConfig) {
   fs.rmSync(path.join(BUILD_DIR, "_stats"), { recursive: true, force: true });
 }
 
-function renderConfiguredWordmark(siteConfig) {
-  const wordmark = siteConfig?.branding?.wordmark;
-  if (!wordmark?.black && !wordmark?.green) {
-    return "<span>Vanity</span><span>URLs</span>";
-  }
-
-  return `<span>${escapeHtml(wordmark.black || "")}</span><span>${escapeHtml(wordmark.green || "")}</span>`;
-}
-
 function renderTestsPanel(language, siteConfig) {
   const metadata = LANGUAGE_METADATA[language] || {
     name: language,
@@ -897,27 +692,6 @@ function renderMachineReadableTestsSection() {
 ${links}
           </ul>
         </section>`;
-}
-
-function withTheme(href, theme) {
-  const separator = href.includes("?") ? "&" : "?";
-  return `${href}${separator}theme=${theme}`;
-}
-
-function encodePathSegment(value) {
-  return encodeURIComponent(String(value || "").trim()).replace(/%2F/gi, "/");
-}
-
-function escapeHtml(value) {
-  return String(value ?? "")
-    .replaceAll("&", "&amp;")
-    .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;");
-}
-
-function escapeHtmlAttribute(value) {
-  return escapeHtml(value).replaceAll("'", "&#39;");
 }
 
 function copyRuntimeBlocklist() {

--- a/scripts/complexity-report.mjs
+++ b/scripts/complexity-report.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import { ESLint } from "eslint";
+
+const ROOT = process.cwd();
+const REPORT_PATH = path.join(ROOT, "build", "eslint-complexity-report.json");
+const TOP_FILE_LIMIT = 8;
+
+const eslint = new ESLint();
+const results = await eslint.lintFiles(["."]);
+
+const messages = results.flatMap((result) =>
+  result.messages.map((message) => ({
+    column: message.column,
+    filePath: path.relative(ROOT, result.filePath),
+    line: message.line,
+    message: message.message,
+    ruleId: message.ruleId || "unknown",
+    severity: message.severity
+  }))
+);
+
+const errors = messages.filter((message) => message.severity === 2);
+const warnings = messages.filter((message) => message.severity === 1);
+const warningFiles = groupBy(warnings, (message) => message.filePath);
+
+fs.mkdirSync(path.dirname(REPORT_PATH), { recursive: true });
+fs.writeFileSync(
+  REPORT_PATH,
+  `${JSON.stringify(
+    {
+      checked_at: new Date().toISOString(),
+      errors: errors.length,
+      warnings: warnings.length,
+      messages
+    },
+    null,
+    2
+  )}\n`
+);
+
+if (!messages.length) {
+  console.log("[complexity] No ESLint complexity warnings.");
+} else {
+  console.log(
+    `[complexity] ${warnings.length} warning${warnings.length === 1 ? "" : "s"}, ${errors.length} error${
+      errors.length === 1 ? "" : "s"
+    } across ${warningFiles.size} file${warningFiles.size === 1 ? "" : "s"}.`
+  );
+  console.log(`[complexity] Detailed report: ${path.relative(ROOT, REPORT_PATH)}`);
+
+  for (const [filePath, fileWarnings] of topEntries(warningFiles, TOP_FILE_LIMIT)) {
+    const topRules = [...groupBy(fileWarnings, (message) => message.ruleId).entries()]
+      .sort((left, right) => right[1].length - left[1].length)
+      .slice(0, 3)
+      .map(([ruleId, ruleWarnings]) => `${ruleId}=${ruleWarnings.length}`)
+      .join(", ");
+    console.log(
+      `[complexity] - ${filePath}: ${fileWarnings.length} warning${fileWarnings.length === 1 ? "" : "s"} (${topRules})`
+    );
+  }
+}
+
+if (errors.length) {
+  process.exitCode = 1;
+}
+
+function groupBy(items, keyForItem) {
+  const groups = new Map();
+  for (const item of items) {
+    const key = keyForItem(item);
+    groups.set(key, [...(groups.get(key) || []), item]);
+  }
+  return groups;
+}
+
+function topEntries(groups, limit) {
+  return [...groups.entries()].sort((left, right) => right[1].length - left[1].length).slice(0, limit);
+}

--- a/scripts/lib/build/html-core.mjs
+++ b/scripts/lib/build/html-core.mjs
@@ -1,0 +1,62 @@
+const DEFAULT_PUBLIC_ASSET_VERSION = "20260601";
+
+export const THEME_OVERRIDE_SCRIPT = `  <script data-v8s-theme-override>
+    (() => {
+      const theme = new URLSearchParams(window.location.search).get("theme");
+      if (theme !== "light" && theme !== "dark") return;
+
+      document.documentElement.dataset.theme = theme;
+
+      const applyThemeImages = () => {
+        document.querySelectorAll('picture source[media*="prefers-color-scheme"][srcset]').forEach((source) => {
+          const image = source.parentElement?.querySelector("img");
+          const candidate =
+            theme === "dark"
+              ? source.getAttribute("srcset")?.split(",")[0]?.trim()?.split(/\\s+/)[0]
+              : image?.getAttribute("src");
+          if (image && candidate) image.src = candidate;
+        });
+      };
+
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", applyThemeImages, { once: true });
+      } else {
+        applyThemeImages();
+      }
+    })();
+  </script>`;
+
+export function normalizeHtmlHead(html, options = {}) {
+  const assetVersion = options.assetVersion || DEFAULT_PUBLIC_ASSET_VERSION;
+  let normalized = normalizePublicAssetVersions(html, assetVersion);
+
+  if (!normalized.includes('rel="icon"')) {
+    normalized = insertBeforeHeadClose(normalized, '  <link rel="icon" type="image/svg+xml" href="/favicon.svg">\n');
+  }
+
+  if (!normalized.includes('rel="apple-touch-icon"')) {
+    normalized = insertBeforeHeadClose(normalized, '  <link rel="apple-touch-icon" href="/apple-touch-icon.png">\n');
+  }
+
+  if (!normalized.includes("data-v8s-theme-override")) {
+    normalized = insertBeforeFirstStylesheet(normalized, `${THEME_OVERRIDE_SCRIPT}\n`);
+  }
+
+  return normalized;
+}
+
+export function normalizePublicAssetVersions(html, assetVersion = DEFAULT_PUBLIC_ASSET_VERSION) {
+  return html.replace(/(href=["']\/style\.css)(?:\?v=\d+)?(["'])/g, `$1?v=${assetVersion}$2`);
+}
+
+export function insertBeforeHeadClose(html, insertion) {
+  return html.replace(/<\/head>/i, `${insertion}</head>`);
+}
+
+export function insertBeforeFirstStylesheet(html, insertion) {
+  if (/<link\s+[^>]*rel=["']stylesheet["'][^>]*>/i.test(html)) {
+    return html.replace(/(<link\s+[^>]*rel=["']stylesheet["'][^>]*>)/i, `${insertion}$1`);
+  }
+
+  return insertBeforeHeadClose(html, insertion);
+}

--- a/scripts/lib/build/site-core.mjs
+++ b/scripts/lib/build/site-core.mjs
@@ -1,0 +1,182 @@
+export function legalPagesEnabled(siteConfig) {
+  return siteConfig?.operator?.legal_pages_enabled !== false;
+}
+
+export function legalPageSlugs(siteConfig) {
+  return legalPagesEnabled(siteConfig) ? ["privacy", "terms", "abuse", "security"] : ["abuse"];
+}
+
+export function siteManifestShortName(siteConfig) {
+  const branding = siteConfig?.branding || {};
+  const wordmark = branding.wordmark || {};
+  const candidates = [
+    branding.domain,
+    siteConfig?.operator?.short_domain,
+    `${wordmark.black || ""}${wordmark.green || ""}`,
+    "VanityURLs"
+  ];
+
+  return candidates.map((value) => String(value || "").trim()).find(Boolean) || "VanityURLs";
+}
+
+export function normalizeSecurityTxtValue(value) {
+  return String(value || "")
+    .trim()
+    .replace(/[\r\n]/g, "");
+}
+
+export function validateOperatorConfig(operator) {
+  const required = [
+    "legal_name",
+    "short_domain",
+    "jurisdiction",
+    "governing_law",
+    "contact_email",
+    "privacy_contact",
+    "abuse_contact",
+    "security_contact",
+    "last_updated",
+    "umami_geo_ip_mode",
+    "analytics_disclosure",
+    "abuse_response_window"
+  ];
+  const issues = required.filter((field) => isPlaceholderValue(operator[field]));
+
+  for (const field of ["contact_email", "privacy_contact", "abuse_contact", "security_contact"]) {
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(String(operator[field]))) {
+      issues.push(field);
+    }
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(operator.last_updated))) {
+    issues.push("last_updated");
+  }
+
+  return [...new Set(issues)];
+}
+
+export function validateTrustConfig(operator) {
+  const required = ["short_domain", "abuse_contact", "security_contact", "last_updated", "abuse_response_window"];
+  const issues = required.filter((field) => isPlaceholderValue(operator[field]));
+
+  for (const field of ["abuse_contact", "security_contact"]) {
+    if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(String(operator[field]))) {
+      issues.push(field);
+    }
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(operator.last_updated))) {
+    issues.push("last_updated");
+  }
+
+  return [...new Set(issues)];
+}
+
+export function validateSecurityConfig(operator) {
+  const required = ["short_domain", "security_contact", "last_updated"];
+  const issues = required.filter((field) => isPlaceholderValue(operator[field]));
+
+  if (!/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(String(operator.security_contact))) {
+    issues.push("security_contact");
+  }
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(String(operator.last_updated))) {
+    issues.push("last_updated");
+  }
+
+  return [...new Set(issues)];
+}
+
+export function hasConfiguredSlogan(slogan) {
+  if (slogan && typeof slogan === "object" && !Array.isArray(slogan)) {
+    return Object.values(slogan).some((value) => String(value || "").trim());
+  }
+  return Boolean(String(slogan || "").trim());
+}
+
+export function renderBrandingSlogan(slogan, operator = {}, linkText = "") {
+  const rendered = escapeHtml(slogan || "");
+  const legalName = String(operator?.legal_name || "").trim();
+  const operatorDomain = normalizeDomain(operator?.operator_domain || "");
+  if (!rendered || !legalName || !operatorDomain) return rendered;
+
+  const linkCandidates = [String(linkText || "").trim(), legalName].filter(Boolean);
+
+  for (const candidate of linkCandidates) {
+    const escapedText = escapeHtml(candidate);
+    if (rendered.includes(escapedText)) {
+      return rendered.replace(
+        escapedText,
+        `<a href="https://${escapeHtmlAttribute(operatorDomain)}">${escapedText}</a>`
+      );
+    }
+  }
+
+  return rendered;
+}
+
+export function localizedSlogan(slogans, language = "en") {
+  if (slogans && typeof slogans === "object" && !Array.isArray(slogans)) {
+    return slogans[language] || slogans.en || "";
+  }
+  return String(slogans || "");
+}
+
+export function localizedSloganLinkText(linkTexts, language = "en") {
+  if (linkTexts && typeof linkTexts === "object" && !Array.isArray(linkTexts)) {
+    return linkTexts[language] || linkTexts.en || "";
+  }
+  return String(linkTexts || "");
+}
+
+export function renderConfiguredWordmark(siteConfig) {
+  const wordmark = siteConfig?.branding?.wordmark;
+  if (!wordmark?.black && !wordmark?.green) {
+    return "<span>Vanity</span><span>URLs</span>";
+  }
+
+  return `<span>${escapeHtml(wordmark.black || "")}</span><span>${escapeHtml(wordmark.green || "")}</span>`;
+}
+
+export function withTheme(href, theme) {
+  const separator = href.includes("?") ? "&" : "?";
+  return `${href}${separator}theme=${theme}`;
+}
+
+export function encodePathSegment(value) {
+  return encodeURIComponent(String(value || "").trim()).replace(/%2F/gi, "/");
+}
+
+export function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+}
+
+export function escapeHtmlAttribute(value) {
+  return escapeHtml(value).replaceAll("'", "&#39;");
+}
+
+function normalizeDomain(value) {
+  return String(value || "")
+    .trim()
+    .replace(/^https?:\/\//i, "")
+    .replace(/\/.*$/g, "")
+    .toLowerCase();
+}
+
+function isPlaceholderValue(value) {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
+  return (
+    !normalized ||
+    ["todo", "tbd", "to be defined", "changeme", "change-me", "default", "owner", "example", "example.com"].includes(
+      normalized
+    ) ||
+    normalized.includes("example.") ||
+    normalized.includes("your-")
+  );
+}

--- a/scripts/maintenance.test.mjs
+++ b/scripts/maintenance.test.mjs
@@ -5,41 +5,8 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { checkUpstreamRelease } from "./lib/upstream-release.mjs";
 
 const ROOT = process.cwd();
-
-{
-  const result = await checkUpstreamRelease({
-    currentVersion: "3.1.5",
-    fetchImpl: async () =>
-      Response.json([
-        {
-          tag_name: "v3.1.7",
-          name: "v3.1.7",
-          body: "Feature release",
-          draft: false,
-          prerelease: false,
-          html_url: "https://github.com/vanityURLs/code/releases/tag/v3.1.7"
-        },
-        {
-          tag_name: "v3.1.6",
-          name: "v3.1.6",
-          body: "Security fix for GHSA-abcd-1234-wxyz",
-          draft: false,
-          prerelease: false,
-          html_url: "https://github.com/vanityURLs/code/releases/tag/v3.1.6"
-        }
-      ])
-  });
-
-  assert.equal(result.ok, true);
-  assert.equal(result.status, "behind-security");
-  assert.equal(result.latestVersion, "3.1.7");
-  assert.equal(result.behindCount, 2);
-  assert.equal(result.security, true);
-  assert.equal(result.securityCount, 1);
-}
 
 function makeFixture() {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "v8s-maintenance-"));

--- a/scripts/upstream-release.test.mjs
+++ b/scripts/upstream-release.test.mjs
@@ -1,0 +1,122 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { checkUpstreamRelease, compareVersions, formatUpstreamReleaseNotice } from "./lib/upstream-release.mjs";
+
+const releases = [
+  release({
+    tag_name: "v3.10.0",
+    name: "v3.10.0",
+    body: "Feature release"
+  }),
+  release({
+    tag_name: "v3.2.1",
+    name: "v3.2.1",
+    body: "Security fix for GHSA-abcd-1234-wxyz"
+  }),
+  release({
+    tag_name: "v3.2.0",
+    name: "v3.2.0",
+    body: "Feature release"
+  }),
+  release({
+    tag_name: "v3.1.9",
+    name: "v3.1.9",
+    body: "Maintenance release"
+  })
+];
+
+{
+  assert(compareVersions("3.10.0", "3.2.1") > 0);
+  assert(compareVersions("v3.2.1", "3.2.1") === 0);
+  assert(compareVersions("3.2.1+build.7", "3.2.0") > 0);
+  assert(compareVersions("3.1.9", "3.2.0") < 0);
+}
+
+{
+  const result = await checkUpstreamRelease({
+    currentVersion: "3.1.8",
+    fetchImpl: jsonFetch(releases)
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, "behind-security");
+  assert.equal(result.latestVersion, "3.10.0");
+  assert.equal(result.behindCount, 4);
+  assert.equal(result.security, true);
+  assert.equal(result.securityCount, 1);
+
+  const notice = formatUpstreamReleaseNotice(result);
+  assert.match(notice, /SECURITY UPDATE/);
+  assert.match(notice, /3\.10\.0/);
+}
+
+{
+  const result = await checkUpstreamRelease({
+    currentVersion: "3.10.0",
+    fetchImpl: jsonFetch([
+      release({ tag_name: "v3.10.1", prerelease: true }),
+      release({ tag_name: "v3.10.0" }),
+      release({ tag_name: "v3.11.0", draft: true })
+    ])
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, "current");
+  assert.equal(result.behind, false);
+  assert.equal(result.latestVersion, "3.10.0");
+}
+
+{
+  const result = await checkUpstreamRelease({
+    currentVersion: "not-a-version",
+    fetchImpl: jsonFetch(releases)
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "unknown-current-version");
+}
+
+{
+  const result = await checkUpstreamRelease({
+    currentVersion: "3.2.0",
+    fetchImpl: jsonFetch([
+      release({ tag_name: "v3.3.0", draft: true }),
+      release({ tag_name: "v3.3.1", prerelease: true })
+    ])
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "no-release");
+}
+
+{
+  const result = await checkUpstreamRelease({
+    currentVersion: "3.2.0",
+    fetchImpl: async () => {
+      throw new Error("offline");
+    }
+  });
+
+  assert.equal(result.ok, false);
+  assert.equal(result.status, "network-unavailable");
+  assert.equal(result.message, "offline");
+  assert.match(formatUpstreamReleaseNotice(result), /skipped: offline/);
+}
+
+console.log("upstream release tests ok");
+
+function jsonFetch(body) {
+  return async () => Response.json(body);
+}
+
+function release({ tag_name, name = tag_name, body = "", draft = false, prerelease = false }) {
+  return {
+    body,
+    draft,
+    html_url: `https://github.com/vanityURLs/code/releases/tag/${tag_name}`,
+    name,
+    prerelease,
+    tag_name
+  };
+}


### PR DESCRIPTION
This Pull Request adds the first complexity-budget and functional-core refactor slice for vanityURLs.

### Detail

This PR:

- adds ESLint-based complexity reporting with a ratchet-friendly budget
- documents the complexity-budget decision in an ADR
- adds focused upstream release tests
- extracts pure build helpers from `scripts/build.mjs` into testable modules
- adds unit coverage for site config, branding, security.txt, and HTML head normalization helpers
- keeps `scripts/build.mjs` closer to an imperative shell that performs filesystem/build orchestration

The goal is to stop silent complexity growth while making future refactors smaller, safer, and easier to review.

### Checks

- [x] `npm run test:build-core`
- [x] `npm run test:build-html-core`
- [x] `npm run build`
- [x] `npm run check`

### Notes

This PR does not change runtime redirect behavior. It moves existing build logic into pure helper modules and adds tests around the extracted behavior.